### PR TITLE
Allow crate to be used in no_std contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Check code formatting
         run: cargo fmt -- --check
       - name: Build clippy
-        run: cargo clippy
+        run: cargo clippy --all-features
       - name: Check clippy lint
-        run: cargo clippy -- -Dwarnings
+        run: cargo clippy --all-features -- -Dwarnings
 
   docs:
     name: Check docs
@@ -53,7 +53,7 @@ jobs:
           profile: minimal
           components: rust-docs
       - name: Check docs
-        run: cargo doc
+        run: cargo doc --all-features
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -75,12 +75,13 @@ jobs:
         with:
           channel: stable
           profile: minimal
+          subcommands: cargo-all-features
       - name: Test build
-        run: cargo build --release
+        run: cargo all-features build --release
       - name: Build tests
-        run: cargo test --no-run
+        run: cargo all-features test --no-run
       - name: Run tests
-        run: cargo test
+        run: cargo all-features test
 
   miri:
     name: Check for UB on ${{ matrix.os }}
@@ -101,12 +102,13 @@ jobs:
           channel: nightly
           profile: minimal
           components: miri
+          subcommands: cargo-all-features
       - name: Build tests
         run: |
           cargo miri setup
-          cargo test --no-run
+          cargo all-features test --no-run
       - name: Run tests
-        run: cargo miri test
+        run: cargo all-features miri test
 
   api:
     name: Check semver and MSV
@@ -127,11 +129,11 @@ jobs:
       - name: Install cargo-semver-checks and cargo-msrv
         run: cargo quickinstall cargo-semver-checks cargo-msrv
       - name: Check semver compatibility
-        run: cargo semver-checks
+        run: cargo semver-checks --all-features
       - name: Check minimum Rust version
         run: |
           cargo msrv set 1.56
-          cargo msrv find --write-msrv --ignore-lockfile
+          cargo msrv find --write-msrv --ignore-lockfile --all-features
           git diff --exit-code
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           channel: stable
           profile: minimal
           subcommands: cargo-all-features
+          cache: binstall
       - name: Test build
         run: cargo all-features build --release
       - name: Build tests
@@ -103,6 +104,7 @@ jobs:
           profile: minimal
           components: miri
           subcommands: cargo-all-features
+          cache: binstall
       - name: Build tests
         run: |
           cargo miri setup
@@ -124,10 +126,8 @@ jobs:
         with:
           channel: stable
           profile: minimal
-      - name: Install cargo-quickinstall
-        run: cargo install cargo-quickinstall
-      - name: Install cargo-semver-checks and cargo-msrv
-        run: cargo quickinstall cargo-semver-checks cargo-msrv
+          subcommands: cargo-semver-checks cargo-msrv
+          cache: binstall
       - name: Check semver compatibility
         run: cargo semver-checks --all-features
       - name: Check minimum Rust version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
       - name: Build tests
         run: cargo all-features test --no-run
       - name: Run tests
-        run: cargo all-features test
+        run: cargo all-features test --lib --bins --tests
+      - name: Run doc tests
+        run: cargo test --doc --all-features
 
   miri:
     name: Check for UB on ${{ matrix.os }}
@@ -110,7 +112,9 @@ jobs:
           cargo miri setup
           cargo all-features test --no-run
       - name: Run tests
-        run: cargo all-features miri test
+        run: cargo all-features miri test --lib --bins --tests
+      - name: Run doc tests
+        run: cargo miri test --doc --all-features
 
   api:
     name: Check semver and MSV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ keywords = ["slice", "index", "parallel", "access", "concurrent"]
 categories = ["concurrency"]
 rust-version = "1.84"
 
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+alloc = []
+default = [ "alloc" ]
+
 [[example]]
 name = "bfs_pointer"
 test = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 
 [features]
 alloc = []
-default = [ "alloc" ]
+default = ["alloc"]
 
 [[example]]
 name = "bfs_pointer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "par_slice"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Matteo Dell'Acqua <dellacqua.matteo99@gmail.com>"]
 description = "Slices that may be accessed from multiple threads with different levels of safety"

--- a/src/impls/collection.rs
+++ b/src/impls/collection.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
-unsafe impl<T> TrustedSizedCollection for Vec<T> {
+#[cfg(feature = "alloc")]
+unsafe impl<T> TrustedSizedCollection for alloc::vec::Vec<T> {
     #[inline]
     fn len(&self) -> usize {
         self.len()

--- a/src/impls/constructor/mod.rs
+++ b/src/impls/constructor/mod.rs
@@ -7,6 +7,8 @@ pub use pointer::*;
 mod unsafe_index;
 pub use unsafe_index::*;
 
+use alloc::boxed::Box;
+
 /// Creates a new boxed slice of `len` elements, each initialized to the return value
 /// of `closure`.
 pub(crate) fn new_boxed_slice_with<T>(len: usize, mut closure: impl FnMut(usize) -> T) -> Box<[T]> {

--- a/src/impls/constructor/no_ref.rs
+++ b/src/impls/constructor/no_ref.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use alloc::boxed::Box;
 
 /// Utility struct for contructors for slices that allow unsynchronized access
 /// to their elements through [`UnsafeNoRefIndex`] and [`UnsafeNoRefChunkIndex`].

--- a/src/impls/constructor/pointer.rs
+++ b/src/impls/constructor/pointer.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use alloc::boxed::Box;
 
 /// Utility struct for contructors for slices that allow unsynchronized access
 /// to their elements through [`PointerIndex`] and [`PointerChunkIndex`].

--- a/src/impls/constructor/unsafe_index.rs
+++ b/src/impls/constructor/unsafe_index.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use alloc::boxed::Box;
 
 /// Utility struct for contructors for slices that allow unsynchronized access
 /// to their elements through [`UnsafeIndex`] and [`UnsafeChunkIndex`].

--- a/src/impls/conversion.rs
+++ b/src/impls/conversion.rs
@@ -41,7 +41,8 @@ unsafe impl<T: Send + Sync> ParIndexView<T> for [T] {
     }
 }
 
-unsafe impl<T: Send + Sync> IntoParIndex<T> for Box<[T]> {
+#[cfg(feature = "alloc")]
+unsafe impl<T: Send + Sync> IntoParIndex<T> for alloc::boxed::Box<[T]> {
     #[inline]
     fn into_pointer_par_index(self) -> impl PointerIndex<T> + ParCollection<T, Self> {
         UnsafeCellSlice::new_owned(self)
@@ -85,7 +86,8 @@ unsafe impl<T: Send + Sync> IntoParIndex<T> for Box<[T]> {
     }
 }
 
-unsafe impl<T: Send + Sync> IntoParIndex<T> for Vec<T> {
+#[cfg(feature = "alloc")]
+unsafe impl<T: Send + Sync> IntoParIndex<T> for alloc::vec::Vec<T> {
     #[inline]
     fn into_pointer_par_index(self) -> impl PointerIndex<T> + ParCollection<T, Self> {
         UnsafeCellSlice::new_owned(self.into_boxed_slice())

--- a/src/impls/index_wrapper.rs
+++ b/src/impls/index_wrapper.rs
@@ -42,7 +42,7 @@ macro_rules! wrapper_method_doc {
 /// [`UnsafeNoRefIndex`], [`UnsafeNoRefChunkIndex`] and [`UnsafeIndex`].
 pub struct IndexWrapper<I, T: ?Sized, B> {
     inner: B,
-    _marker: std::marker::PhantomData<(I, T)>,
+    _marker: core::marker::PhantomData<(I, T)>,
 }
 
 impl<T: ?Sized, B: ParView<T>> IndexWrapper<(), T, B> {
@@ -58,7 +58,7 @@ impl<T: ?Sized, B: ParView<T>> IndexWrapper<(), T, B> {
     pub fn new<I: AsUsize>(collection: B) -> IndexWrapper<I, T, B> {
         IndexWrapper {
             inner: collection,
-            _marker: std::marker::PhantomData,
+            _marker: core::marker::PhantomData,
         }
     }
 }

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -2,7 +2,9 @@ mod collection;
 
 mod conversion;
 
+#[cfg(feature = "alloc")]
 mod constructor;
+#[cfg(feature = "alloc")]
 pub use constructor::*;
 
 mod indexing;

--- a/src/impls/unsafe_cell_chunk_slice.rs
+++ b/src/impls/unsafe_cell_chunk_slice.rs
@@ -1,5 +1,7 @@
 use crate::*;
-use std::{cell::UnsafeCell, mem::size_of, ops::Deref};
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
+use core::{cell::UnsafeCell, mem::size_of, ops::Deref};
 
 /// Wrapper around an [`UnsafeCell`] (either mutable reference or owned)
 /// that divides the underlying slice in chunks.
@@ -13,8 +15,10 @@ pub(crate) struct UnsafeCellChunkSlice<B> {
 // Safety: access paradigms shift responsability to the user to ensure
 // no data races happen.
 unsafe impl<T: Send + Sync> Sync for UnsafeCellChunkSlice<&mut UnsafeCell<[T]>> {}
+#[cfg(feature = "alloc")]
 unsafe impl<T: Send + Sync> Sync for UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>> {}
 
+#[cfg(feature = "alloc")]
 impl<T> From<UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>>> for Box<[T]> {
     #[inline]
     fn from(value: UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>>) -> Self {
@@ -22,6 +26,7 @@ impl<T> From<UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>>> for Box<[T]> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T> From<UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>>> for Vec<T> {
     #[inline]
     fn from(value: UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>>) -> Self {
@@ -47,6 +52,7 @@ impl<'a, T> UnsafeCellChunkSlice<&'a mut UnsafeCell<[T]>> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T> UnsafeCellChunkSlice<Box<UnsafeCell<[T]>>> {
     /// Creates a new owned slice with chunks of `chunk_size`.
     ///
@@ -127,7 +133,7 @@ unsafe impl<T, B: Deref<Target = UnsafeCell<[T]>>> PointerIndex<[T]> for UnsafeC
             // offset stays in bounds of allocated object
             ptr = ptr.add(offset);
         }
-        std::ptr::slice_from_raw_parts_mut(ptr, self.chunk_size)
+        core::ptr::slice_from_raw_parts_mut(ptr, self.chunk_size)
     }
 }
 

--- a/src/impls/unsafe_cell_slice.rs
+++ b/src/impls/unsafe_cell_slice.rs
@@ -1,5 +1,7 @@
 use crate::*;
-use std::{cell::UnsafeCell, mem::size_of, ops::Deref};
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
+use core::{cell::UnsafeCell, mem::size_of, ops::Deref};
 
 /// Wrapper around an [`UnsafeCell`] (either mutable reference or owned).
 #[derive(Debug)]
@@ -8,8 +10,10 @@ pub(crate) struct UnsafeCellSlice<B>(B);
 // Safety: access paradigms shift responsability to the user to ensure
 // no data races happen.
 unsafe impl<T: Send + Sync> Sync for UnsafeCellSlice<&mut UnsafeCell<[T]>> {}
+#[cfg(feature = "alloc")]
 unsafe impl<T: Send + Sync> Sync for UnsafeCellSlice<Box<UnsafeCell<[T]>>> {}
 
+#[cfg(feature = "alloc")]
 impl<T> From<UnsafeCellSlice<Box<UnsafeCell<[T]>>>> for Box<[T]> {
     #[inline]
     fn from(value: UnsafeCellSlice<Box<UnsafeCell<[T]>>>) -> Self {
@@ -17,6 +21,7 @@ impl<T> From<UnsafeCellSlice<Box<UnsafeCell<[T]>>>> for Box<[T]> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T> From<UnsafeCellSlice<Box<UnsafeCell<[T]>>>> for Vec<T> {
     #[inline]
     fn from(value: UnsafeCellSlice<Box<UnsafeCell<[T]>>>) -> Self {
@@ -31,6 +36,7 @@ impl<'a, T> UnsafeCellSlice<&'a mut UnsafeCell<[T]>> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T> UnsafeCellSlice<Box<UnsafeCell<[T]>>> {
     /// Creates a new owned slice.
     pub(crate) fn new_owned(slice: Box<[T]>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! ParSlice is a utility crate to allow easier access to data in parallel
 //! when data races are avoided at compile time or through other means but the
 //! compiler has no way to know.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![no_std]
 
 //! ParSlice is a utility crate to allow easier access to data in parallel
 //! when data races are avoided at compile time or through other means but the
@@ -270,3 +271,6 @@ pub use impls::*;
 
 mod traits;
 pub use traits::*;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,13 @@
 //! }
 //! ```
 //!
+//! # no_std
+//!
+//! This crate is `no_std` compatible.
+//!
+//! By default the `alloc` feature is enabled and allows to use heap-allocated structures,
+//! but requires the `alloc` crate.
+//!
 //! [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 mod impls;
 pub use impls::*;

--- a/src/traits/collection.rs
+++ b/src/traits/collection.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// A sized collection.
 ///

--- a/src/traits/conversion.rs
+++ b/src/traits/conversion.rs
@@ -294,8 +294,8 @@ pub unsafe trait ParIndexView<T> {
 ///   chunk 1 includes indices from 4 to 7, etc.).
 /// * All returned collections must implement [`Into`] to convert back to the original collection
 ///   type. The input collection's original internal state beside size is not guaranteed to be preserved
-///   (*i.e.* a [`Vec`] can possess a different [`capacity`](Vec::capacity) when converted back, but
-///   the [`len`](`Vec::len`) must be the same, as well as the indexes of its elements).
+///   (*i.e.* a [`Vec`](alloc::vec::Vec) can possess a different [`capacity`](alloc::vec::Vec::capacity) when converted back, but
+///   the [`len`](`alloc::vec::Vec::len`) must be the same, as well as the indexes of its elements).
 ///
 /// # Examples
 ///

--- a/tests/owned_no_ref_chunk_slice.rs
+++ b/tests/owned_no_ref_chunk_slice.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use par_slice::*;
 use std::thread::scope;
 

--- a/tests/owned_no_ref_slice.rs
+++ b/tests/owned_no_ref_slice.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use par_slice::*;
 use std::thread::scope;
 

--- a/tests/owned_pointer_chunk_slice.rs
+++ b/tests/owned_pointer_chunk_slice.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use par_slice::*;
 use std::thread::scope;
 

--- a/tests/owned_pointer_slice.rs
+++ b/tests/owned_pointer_slice.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use par_slice::*;
 use std::thread::scope;
 

--- a/tests/owned_unsafe_chunk_slice.rs
+++ b/tests/owned_unsafe_chunk_slice.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use par_slice::*;
 use std::thread::scope;
 

--- a/tests/owned_unsafe_slice.rs
+++ b/tests/owned_unsafe_slice.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "alloc")]
 use par_slice::*;
 use std::thread::scope;
 


### PR DESCRIPTION
Allow no_std contexts (with alloc for owned structures)